### PR TITLE
Add extension for diabolo6 ransomware

### DIFF
--- a/resources/extensions.txt
+++ b/resources/extensions.txt
@@ -363,3 +363,5 @@ _ryp
 .ZINO
 .zorro
 .zyklon
+.diabolo6
+.lukitus


### PR DESCRIPTION
There seems to be a new version of the Locky ransomware:
https://www.heise.de/security/meldung/Locky-ist-wieder-da-Erpressungstrojaner-grassiert-jetzt-als-Diablo6-3806833.html