### PR TITLE
Remove .aac from blacklisted extensions

### DIFF
--- a/resources/extensions.txt
+++ b/resources/extensions.txt
@@ -209,7 +209,6 @@ keybtc@inbox_com
 .кибер разветвитель
 .maktub
 .__AiraCropEncrypted!
-.aac
 .nuclear55
 _nullbyte
 .odcodc


### PR DESCRIPTION
.aac is an (albeit uncommon) file extension for audio encoded in the AAC format. Although most such files are saved as .m4a, I do believe this is a false positive. Source: https://fileinfo.com/extension/aac